### PR TITLE
feat: Switch default network from Base to Celo

### DIFF
--- a/context/wagmiContext.tsx
+++ b/context/wagmiContext.tsx
@@ -3,7 +3,7 @@
 import { wagmiAdapter, projectId } from "@/utils/config";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createAppKit } from "@reown/appkit/react";
-import { base, optimism } from "@reown/appkit/networks";
+import { celo, optimism } from "@reown/appkit/networks";
 import { cookieToInitialState, WagmiProvider, type Config } from "wagmi";
 
 
@@ -25,8 +25,8 @@ const metadata = {
 const modal = createAppKit({
   adapters: [wagmiAdapter],
   projectId,
-  networks: [base, optimism],
-  defaultNetwork: base,
+  networks: [celo, optimism],
+  defaultNetwork: celo,
   metadata: metadata,
   features: {
     analytics: true // Optional - defaults to your Cloud configuration

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,6 +1,6 @@
 import { cookieStorage, createStorage, http } from "@wagmi/core"
 import { WagmiAdapter } from "@reown/appkit-adapter-wagmi"
-import { base, optimism } from "@reown/appkit/networks"
+import { celo, optimism } from "@reown/appkit/networks"
 
 // Get projectId from https://dashboard.reown.com
 export const projectId = process.env.NEXT_PUBLIC_WC_PROJECT_ID
@@ -10,7 +10,7 @@ if (!projectId) {
   throw new Error("Project ID is not defined")
 }
 
-export const networks = [base, optimism]
+export const networks = [celo, optimism]
 
 //Set up the Wagmi Adapter (Config)
 export const wagmiAdapter = new WagmiAdapter({


### PR DESCRIPTION
Replaces the Base network with Celo as the default and in supported networks for both wagmi context and config. This change updates the app to use Celo and Optimism networks instead of Base and Optimism.