### PR TITLE
feat: Update referral SDK usage in useDivvi hook

### DIFF
--- a/hooks/useDivvi.tsx
+++ b/hooks/useDivvi.tsx
@@ -1,23 +1,24 @@
 import { publicClient } from "@/utils/client"
 import { fleetOrderBook } from "@/utils/constants/addresses"
-import { getDataSuffix, submitReferral } from "@divvi/referral-sdk"
+import { getReferralTag, submitReferral } from "@divvi/referral-sdk"
 import { useState } from "react"
 import { toast } from "sonner"
-import { createWalletClient, custom, encodeFunctionData, erc20Abi, maxUint256 } from "viem"
+import { encodeFunctionData, erc20Abi, maxUint256 } from "viem"
 import { celo } from "viem/chains"
+import { useAccount, useSendTransaction, useSwitchChain } from "wagmi";
+
 
 export const useDivvi = () => {
   
     const [loading, setLoading] = useState(false)
-  
+    const { sendTransactionAsync } = useSendTransaction();
+    const { chainId } = useAccount()
+    const { switchChainAsync } = useSwitchChain()
+
     async function registerUser(account: `0x${string}`, to: `0x${string}`) {
       try {
         setLoading(true)
-        // Step 1: Create a wallet client and get the account
-        const walletClient = createWalletClient({
-          chain: celo,
-          transport: custom(window.ethereum as any),
-        })
+        
 
         const data = encodeFunctionData({
           abi: erc20Abi,
@@ -25,41 +26,42 @@ export const useDivvi = () => {
           args: [fleetOrderBook, maxUint256]
         })
         
-        // Step 2: Execute an existing transaction within your codebase with the referral data suffix
 
         // consumer is your Divvi Identifier
-        // providers are the addresses of the Rewards Campaigns that you signed up for on the previous page
-        const dataSuffix = getDataSuffix({
+        // generate a referral tag for the user
+        const referralTag  = getReferralTag({
+          user: account,
           consumer: "0x99342D3CE2d10C34b7d20D960EA75bd742aec468",
-          providers: ["0x5f0a55FaD9424ac99429f635dfb9bF20c3360Ab8", "0xB06a1b291863f923E7417E9F302e2a84018c33C5", "0x6226ddE08402642964f9A6de844ea3116F0dFc7e", "0x0423189886D7966f0DD7E7d256898DAeEE625dca"]
-        })
-        const txHash = await walletClient.sendTransaction({
-          account,
-          to: to,
-          data: data + dataSuffix as `0x${string}`,
-          value: BigInt(0),
-          // ... other transaction parameters
         })
 
-         
+        if (chainId !== celo.id) {
+          await switchChainAsync({ chainId: celo.id })
+        }
+        
+        //Send the transaction your dapp was already going to perform (e.g. swap, transfer, contract interaction), but add the referral tag to the `data` field to enable attribution tracking.
+        const hash = await sendTransactionAsync({
+          to: to,
+          data: data + referralTag as `0x${string}`,
+          value: BigInt(0),
+          chainId: celo.id
+        })
+        
         const transaction = await publicClient.waitForTransactionReceipt({
           confirmations: 1,
-          hash: txHash
+          hash: hash
         })
-        // Step 3: Get the chain ID of the chain that the transaction was sent to
-        const chainId = await walletClient.getChainId()
 
-        // Step 4: Report the transaction to the attribution tracking API
+        // Report the transaction to Divvi by calling `submitReferral`. Divvi will later decode the referral metadata from the transaction data and record the referral on-chain via the DivviRegistry contract.
         if (transaction) {
           await submitReferral({
-            txHash,
-            chainId
+            txHash: hash,
+            chainId: celo.id
           })
-          setLoading(false)
-          toast.info("Approval successful", {
-            description: "You can now purchase the 3-Wheelers",
-          })
-        }    
+        }
+        setLoading(false) 
+        toast.info("Approval successful", {
+          description: "You can now purchase the 3-Wheelers",
+        })
       } catch (error) {
         console.log(error)
         setLoading(false)


### PR DESCRIPTION
Replaces getDataSuffix with getReferralTag from @divvi/referral-sdk and updates transaction data construction to use referralTag. Improves comments for clarity on referral tag generation and reporting to Divvi.