### PR TITLE
feat: Add useOrderFleet hook and integrate in Wrapper

### DIFF
--- a/components/fleet/buy/wrapper.tsx
+++ b/components/fleet/buy/wrapper.tsx
@@ -25,6 +25,7 @@ import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { divviAbi } from "@/utils/abis/divvi";
 import { useApprove } from "@/hooks/useApprove";
+import { useOrderFleet } from "@/hooks/useOrderFleet";
 import { useSendTransaction } from "wagmi";
 import { publicClient } from "@/utils/client";
 import { useSwitchChain } from "wagmi";
@@ -61,7 +62,7 @@ export function Wrapper() {
 
     const { sendTransactionAsync } = useSendTransaction();
     const { approve, loadingApproval } = useApprove()
-
+    const { orderFleet, loadingOrderFleet } = useOrderFleet()
 
 
     //increase and decrease amount...
@@ -142,7 +143,7 @@ export function Wrapper() {
         compliantQueryClient.invalidateQueries({ queryKey: compliantQueryKey }) 
     }, [blockNumber, compliantQueryClient, compliantQueryKey]) 
 
-
+/*
     // order multiple fleet with celoUSD
     async function orderFleetWithCeloUSD() { 
         try {
@@ -180,7 +181,7 @@ export function Wrapper() {
             setLoadingCeloUSD(false)
         }
     }
-
+*/
 
     // order fleet fractions & single 3-Wheeler with celoUSD
     async function orderFleetFractionsWithCeloUSD( shares: number ) {    
@@ -337,7 +338,7 @@ export function Wrapper() {
                                                     if ( (Number(formatUnits(tokenBalance!, 18))) < Math.ceil(amount * (Number(fleetFractionPrice) * 50)) ) {
                                                         onRamp()
                                                     } else {
-                                                        orderFleetWithCeloUSD()
+                                                        orderFleet(address!, amount)
                                                     }
                                                     
                                                 }

--- a/hooks/useOrderFleet.tsx
+++ b/hooks/useOrderFleet.tsx
@@ -1,0 +1,80 @@
+import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook"
+import { publicClient } from "@/utils/client"
+import { cUSD, fleetOrderBook } from "@/utils/constants/addresses"
+import { getReferralTag, submitReferral } from "@divvi/referral-sdk"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { toast } from "sonner"
+import { encodeFunctionData } from "viem"
+import { celo } from "viem/chains"
+import { useAccount, useSendTransaction, useSwitchChain } from "wagmi";
+
+
+export const useOrderFleet = () => {
+  
+    const [loadingOrderFleet, setLoadingOrderFleet] = useState(false)
+    const { sendTransactionAsync } = useSendTransaction();
+    const { chainId } = useAccount()
+    const { switchChainAsync } = useSwitchChain()
+
+    const router = useRouter()
+
+    async function orderFleet(account: `0x${string}`, amount: number, ) {
+      try {
+        setLoadingOrderFleet(true)
+        
+
+        const data = encodeFunctionData({
+          abi: fleetOrderBookAbi,
+          functionName: "orderFleet",
+          args: [BigInt(amount), cUSD, account!],
+        })
+        
+
+        // consumer is your Divvi Identifier
+        // generate a referral tag for the user
+        const referralTag  = getReferralTag({
+          user: account,
+          consumer: "0x99342D3CE2d10C34b7d20D960EA75bd742aec468",
+        })
+
+        if (chainId !== celo.id) {
+          await switchChainAsync({ chainId: celo.id })
+        }
+        
+        //Send the transaction your dapp was already going to perform (e.g. swap, transfer, contract interaction), but add the referral tag to the `data` field to enable attribution tracking.
+        const hash = await sendTransactionAsync({
+          to: fleetOrderBook,
+          data: data + referralTag as `0x${string}`,
+          value: BigInt(0),
+          chainId: celo.id
+        })
+        
+        const transaction = await publicClient.waitForTransactionReceipt({
+          confirmations: 1,
+          hash: hash
+        })
+
+        // Report the transaction to Divvi by calling `submitReferral`. Divvi will later decode the referral metadata from the transaction data and record the referral on-chain via the DivviRegistry contract.
+        if (transaction) {
+          await submitReferral({
+            txHash: hash,
+            chainId: celo.id
+          })
+        }
+        setLoadingOrderFleet(false) 
+        toast.success("Purchase successful", {
+          description: `You can now view your ${amount > 1 ? "3-Wheelers" : " 3-Wheeler"} in your fleet`,
+        })
+        router.push("/fleet")
+      } catch (error) {
+        console.log(error)
+        setLoadingOrderFleet(false)
+        toast.error("Purchase failed", {
+          description: `Something went wrong, please try again`,
+      })
+      }   
+    }
+    return { orderFleet, loadingOrderFleet }
+  
+}


### PR DESCRIPTION
Introduces the useOrderFleet hook to handle fleet ordering with referral tracking and transaction management. Refactors Wrapper component to use the new hook, replacing the previous orderFleetWithCeloUSD function for improved modularity and maintainability.