### PR TITLE
feat: Refactor fleet buy wrapper to remove unused celoUSD logic

### DIFF
--- a/components/fleet/buy/wrapper.tsx
+++ b/components/fleet/buy/wrapper.tsx
@@ -19,7 +19,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { divvi, fleetOrderBook, cUSD } from "@/utils/constants/addresses";
 import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook";
-import { encodeFunctionData, erc20Abi, formatUnits } from "viem";
+import { erc20Abi, formatUnits } from "viem";
 import { celo, optimism } from "viem/chains";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
@@ -27,23 +27,17 @@ import { divviAbi } from "@/utils/abis/divvi";
 import { useApprove } from "@/hooks/useApprove";
 import { useOrderFleet } from "@/hooks/useOrderFleet";
 import { useOrderFleetFraction } from "@/hooks/useOrderFleetFraction";
-import { useSendTransaction } from "wagmi";
-import { publicClient } from "@/utils/client";
-import { useSwitchChain } from "wagmi";
 import { OnRamp } from "@/components/fleet/buy/onRamp";
 
 
 export function Wrapper() {
 
-    const { address, chainId } = useAccount()
-    const { switchChainAsync } = useSwitchChain()
-    console.log(chainId)
+    const { address } = useAccount()
 
     const [openDrawer, setOpenDrawer] = useState(true)
     
     const [amount, setAmount] = useState(1)
     const [fractions, setFractions] = useState(1)
-    const [loadingCeloUSD, setLoadingCeloUSD] = useState(false)
     const [loadingAddCeloDollar, setLoadingAddCeloDollar] = useState(false)
         
     const [isFractionsMode, setIsFractionsMode] = useState(true)
@@ -61,7 +55,7 @@ export function Wrapper() {
     const compliantQueryClient = useQueryClient()
     const { data: blockNumber } = useBlockNumber({ watch: true }) 
 
-    const { sendTransactionAsync } = useSendTransaction();
+    
     const { approve, loadingApproval } = useApprove()
     const { orderFleet, loadingOrderFleet } = useOrderFleet()
     const { orderFleetFraction, loadingOrderFleetFraction } = useOrderFleetFraction()
@@ -144,86 +138,7 @@ export function Wrapper() {
         compliantQueryClient.invalidateQueries({ queryKey: compliantQueryKey }) 
     }, [blockNumber, compliantQueryClient, compliantQueryKey]) 
 
-/*
-    // order multiple fleet with celoUSD
-    async function orderFleetWithCeloUSD() { 
-        try {
-            setLoadingCeloUSD(true)
-            if (chainId !== celo.id) {
-               await switchChainAsync({ chainId: celo.id })
-            }
-            const hash = await sendTransactionAsync({
-                to: fleetOrderBook,
-                data: encodeFunctionData({
-                    abi: fleetOrderBookAbi,
-                    functionName: "orderFleet",
-                    args: [BigInt(amount), cUSD, address!],
-                }),
-                chainId: celo.id,
-            })
-            const transaction = await publicClient.waitForTransactionReceipt({
-                confirmations: 1,
-                hash: hash
-            })
-              
-            if (transaction) {
-                //success toast
-                toast.success("Purchase successful", {
-                    description: `You can now view your ${amount > 1 ? "3-Wheelers" : " 3-Wheeler"} in your fleet`,
-                })
-                setLoadingCeloUSD(false)
-                router.push("/fleet")
-            }
-        } catch (error) {
-            console.log(error)
-            toast.error("Purchase failed", {
-                description: `Something went wrong, please try again`,
-            })
-            setLoadingCeloUSD(false)
-        }
-    }
-*/
-/*
-    // order fleet fractions & single 3-Wheeler with celoUSD
-    async function orderFleetFractionsWithCeloUSD( shares: number ) {    
-        try {
-            setLoadingCeloUSD(true)
-            if (chainId !== celo.id) {
-                await switchChainAsync({ chainId: celo.id })
-            }
-            const hash = await sendTransactionAsync({
-                to: fleetOrderBook,
-                data: encodeFunctionData({
-                    abi: fleetOrderBookAbi,
-                    functionName: "orderFleetFraction",
-                    args: [BigInt(shares), cUSD, address!],
-                }),
-                chainId: celo.id,
-            })
-            const transaction = await publicClient.waitForTransactionReceipt({
-                confirmations: 1,
-                hash: hash
-            })
-
-            if (transaction) {
-                //success toast
-                toast.success("Purchase successful", {
-                    description: `You can now view your 3-Wheeler ${shares == 50 ? "" : `${shares > 1 ? "fractions" : "fraction"}`} in your fleet`,
-                })
-
-                setLoadingCeloUSD(false)
-                router.push("/fleet")
-            }
-        } catch (error) {
-            console.log(error)
-            toast.error("Purchase failed", {
-                description: `Something went wrong, please try again`,
-            })
-            setLoadingCeloUSD(false)
-        }
-    }
-*/
-
+    
     const onRamp = () => {
         setLoadingAddCeloDollar(true)
         setOpenOnRamp(true)
@@ -326,7 +241,7 @@ export function Wrapper() {
                                     {/**pay with celoUSD */}
                                     <Button 
                                         className={` ${allowanceCeloUSD && allowanceCeloUSD > 0 ? "w-full hover:bg-yellow-600" : "w-full bg-yellow-300 hover:bg-yellow-400"}` }
-                                        disabled={loadingCeloUSD  || loadingApproval} 
+                                        disabled={loadingOrderFleet || loadingOrderFleetFraction  || loadingApproval} 
                                         onClick={() => {
                                             if (allowanceCeloUSD && allowanceCeloUSD > 0) {
                                                 if (isFractionsMode) {
@@ -360,7 +275,7 @@ export function Wrapper() {
                                         }}
                                     >
                                         {
-                                            loadingCeloUSD || loadingApproval || loadingAddCeloDollar
+                                            loadingOrderFleet || loadingOrderFleetFraction || loadingApproval || loadingAddCeloDollar
                                             ? (
                                                 <Loader2 className="w-4 h-4 animate-spin" /> 
                                             )


### PR DESCRIPTION
Removed unused celoUSD transaction logic and related state from the fleet buy wrapper. Updated button and control loading states to use orderFleet and orderFleetFraction loading flags instead of the previous loadingCeloUSD state.